### PR TITLE
Add Agora x Gemma Voice Coach

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@
 - [MedGemma Impact Challenge](https://www.kaggle.com/competitions/med-gemma-impact-challenge/hackathon-winners) — The winners of the MedGemma hackathon to build human-centered AI applications with MedGemma.
 - [Gemma-Translator](https://github.com/google-gemma/gemma-translator) — A fully offline device powered by Gemma 4 E2B built with Google Antigravity.
 - [Real-Time Voice AI with Gemma 4](https://huggingface.co/blog/cerebras-gemma4-voice-ai) — Open-source cascaded voice stack using Gemma 4 for low-latency reasoning.
+- [Agora x Gemma Voice Coach](https://github.com/anandwana001/Agora-Gemma-Voice-Coach) — A local Next.js demo combining Agora Conversational AI with a local Gemma reasoning layer for live voice coaching sessions.
 
 ## Gemma 4 Good Challenge
 


### PR DESCRIPTION
## Summary
- Add Agora x Gemma Voice Coach to Demos and Applications.

## Notes
- The project is a local Next.js demo that combines Agora Conversational AI with a local Gemma reasoning layer for live voice coaching sessions.

@MaartenGr PTAL