### PR TITLE
Add gemma4.c

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@
 - [While I slept, my 5-year-old MacBook ran Gemma 4 locally and indexed a year of video](https://blog.simbastack.com/indexed-a-year-of-video-locally/)
 - [Fine-tuning Gemma 4 12B on your own data](https://x.com/akshay_pachaar/status/2063610194618396728)
 - [Turning Gemma 4 into an Old Korean Translator](https://dev.to/googleai/turning-gemma-4-into-an-old-korean-translator-hop)
+- [gemma4.c](https://github.com/ryansenn/gemma4.c) — An educational implementation of Gemma 4 E2B CPU inference in pure C.
 
 ## Demos and Applications
 


### PR DESCRIPTION
gemma4.c is a small implementation of Gemma 4 E2B text inference in pure C. The goal is to make Gemma 4 inference easier to understand by showing the entire implementation in a single file.

It implements tokenization, embeddings, RMSNorm, RoPE, sliding/full attention, KV caching, the GeGLU MLP, Gemma 4’s per-layer inputs, int8 weight and activation quantization, logits, sampling, and autoregressive generation.

The repo also includes benchmarks against llama.cpp and numerical validation against the Hugging Face implementation.