### PR TITLE
Add Needle to Demos and Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@
 - [MedGemma Impact Challenge](https://www.kaggle.com/competitions/med-gemma-impact-challenge/hackathon-winners) — The winners of the MedGemma hackathon to build human-centered AI applications with MedGemma.
 - [Gemma-Translator](https://github.com/google-gemma/gemma-translator) — A fully offline device powered by Gemma 4 E2B built with Google Antigravity.
 - [Real-Time Voice AI with Gemma 4](https://huggingface.co/blog/cerebras-gemma4-voice-ai) — Open-source cascaded voice stack using Gemma 4 for low-latency reasoning.
+- [Needle](https://github.com/aitrailblazer/needle-arm64-mobile-ai) — Offline Gemma 4 E2B micro-router for bounded knowledge tasks on Arm64 iPhones, with host-validated native execution and local audit receipts.
 
 ## Gemma 4 Good Challenge
 


### PR DESCRIPTION
Adds Needle, an open-source, offline Gemma 4 E2B application for Arm64 iPhones.

Needle uses Gemma through llama.cpp to convert natural-language requests into schema-constrained proposals for a fixed catalog of local knowledge tasks. A Swift host validates each proposal, executes the permitted native operation, and records a local audit receipt.

The project includes source code, a physical-device demonstration, and reproducible evaluation evidence.