### PR TITLE
Add Apple Core AI to Local inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@
 - [React Native](https://github.com/software-mansion/react-native-executorch/tree/main/apps/llm) — Run on-device Gemma models within React Native using ExecuTorch.
 - [GenieX](https://aihub.qualcomm.com/models/gemma_4_e4b_it) — Run Gemma on Qualcomm hardware.
 - [Docker](https://hub.docker.com/r/ai/gemma4) — Run Gemma 4 in Docker.
+- [Apple Core AI](https://huggingface.co/collections/mlboydaisuke/gemma-4-for-apple-core-ai-6a9b24ba16891680acaaba21) — Community Gemma 4 bundles (E2B, E4B, 12B, 31B) for Apple's on-device Core AI framework, each with recipe and measured speed.
 
 
 ### Hosted


### PR DESCRIPTION
Thanks for maintaining this list. This adds one entry at the bottom of Local, in the list's format: a collection of community Core AI `.aimodel` bundles of Gemma 4 E2B, E4B, 12B and 31B for iOS 27 / macOS 27. Each card carries the conversion recipe and measured decode speed (E2B: 30 tok/s on iPhone 17 Pro, 77 tok/s on M4 Max; 31B: 17 tok/s on M4 Max). E2B and E4B are greedy-exact against the HF reference (8/8). If anything is off, I'll fix it. Thanks again.



---

One data point behind this entry, in case it's useful.

In a small test I ran, coding agents building on-device apps shortlisted Gemma in 7 of 12 runs and chose it once. In 4 of those 7, what stopped it was the gated download, not the model. None of the 30 runs mentioned Gemma 4, which has no gate.

Their own notes: “excellent quality/size and a natural fit for MediaPipe, but the HF repo is gated (licence acceptance), which complicates an unattended download step” (Fable, on Gemma 3 1B); “anonymous download returned `GatedRepo`, so there was no legal/authenticated way to fetch and push the model in this environment” (Codex, after choosing Gemma 3 1B on LiteRT-LM). The setup: three agents (Claude Fable 5.1, Claude Sonnet 5, Codex with GPT-5.5), ten on-device app tasks each, no hint about which model or runtime to use, and each agent wrote down its choice and reason before coding. I ran it to see how agents treat the models I convert.

The bundles in this entry have no gate, and each card shows how it was made and how fast it runs. None of the 30 runs opened this list, so I don't know whether an entry here reaches an agent.

I repeat the run monthly. If this lands, I'll post here what the agents pick next time, whichever way it goes. Nothing is needed from you for that. Thanks again.
